### PR TITLE
Add unit tests for org.mapdb.io.DataIO

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,5 +71,8 @@ dependencies {
     testRuntime("org.junit.vintage:junit-vintage-engine:$junit_version")
 
     testCompile("org.junit.jupiter:junit-jupiter-api:$junit_version")
+    testCompile("com.diffblue:deeptestutils:1.9.0")
+    testCompile("org.mockito:mockito-core:1.10.19")
+    testCompile("org.powermock:powermock-module-junit4:1.6.5")
     testRuntime("org.junit.jupiter:junit-jupiter-engine:$junit_version")
 }


### PR DESCRIPTION
I've analysed your codebase and noticed that `org.mapdb.io.DataIO` is not fully tested.
I've written some tests for the methods in this class with the help of [Diffblue Cover](https://www.diffblue.com/opensource).

Hopefully, these tests will help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other classes that you consider important in a subsequent PR.